### PR TITLE
Replace main queue for a background queue

### DIFF
--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -54,7 +54,7 @@ public class TelemetryManager {
         // Do not send telemetry from simulator
         guard !isSimulator else { return }
 
-        DispatchQueue.main.async { [self] in
+        DispatchQueue.global().async { [self] in
             let path = "/api/v1/apps/\(configuration.telemetryAppID)/signals/"
             let url = configuration.telemetryServerBaseURL.appendingPathComponent(path)
 


### PR DESCRIPTION
This is meant to avoid locking the main thread, because it's not actually affecting the UI, or something particular to the main thread, it should be safe to use a background thread instead