### PR TITLE
Added telemetryAllowDebugBuilds to the Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,4 @@ Telemetry Manager will automatically send a base payload with these keys:
 - operatingSystem
 - targetEnvironment
 
-NOTE: Telemetry Manager will *not* send any signals if you are in DEBUG Mode. To try out if your configuration works, temporarily
-set your Run schema to RELEASE instead. 
+NOTE: Telemetry Manager will *not* send any signals if you are in DEBUG Mode. You can override this by setting `configuration.telemetryAllowDebugBuilds = true` on your `TelemetryManagerConfiguration` instance.

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -21,9 +21,10 @@ import TVUIKit
 #endif
 
 public typealias TelemetrySignalType = String
-public struct TelemetryManagerConfiguration {
+public final class TelemetryManagerConfiguration {
     public let telemetryAppID: String
     public let telemetryServerBaseURL: URL
+    public var telemetryAllowDebugBuilds: Bool = false
     
     public init(appID: String, baseURL: URL? = nil) {
         self.telemetryAppID = appID
@@ -56,8 +57,11 @@ public class TelemetryManager {
     public func send(_ signalType: TelemetrySignalType, for clientUser: String? = nil, with additionalPayload: [String: String] = [:]) {
         // Do not send telemetry in DEBUG mode
         #if DEBUG
-        return
-        #else
+        if configuration.telemetryAllowDebugBuilds == false
+        {
+            return
+        }
+        #endif
 
         DispatchQueue.global().async { [self] in
             let path = "/api/v1/apps/\(configuration.telemetryAppID)/signals/"
@@ -93,7 +97,6 @@ public class TelemetryManager {
             }
             task.resume()
         }
-        #endif
     }
     
     private init(configuration: TelemetryManagerConfiguration) {


### PR DESCRIPTION
I cannot run a Release build for the simulator. This PR allows you to override the DEBUG/RELEASE block as needed for testing, but defaults to the old behaviour of blocking DEBUG builds.

To allow changing variables on the Configuration I had to make it a class instead of struct. This also gives you scope to add more options in the future.
