### PR TITLE
In-Memory Caching

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "TelemetryClient",
+    platforms: [
+        .macOS(.v10_13),
+        .iOS(.v12)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/TelemetryClient/JSONFormatting.swift
+++ b/Sources/TelemetryClient/JSONFormatting.swift
@@ -1,0 +1,75 @@
+//
+//  JSONFormatting.swift
+//
+//
+//  Created by Daniel Jilg on 23.06.21.
+//
+
+import Foundation
+
+extension Formatter {
+    static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static let iso8601noFS = ISO8601DateFormatter()
+
+    static let iso8601dateOnly: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withFullDate]
+        return formatter
+    }()
+}
+
+extension JSONDecoder.DateDecodingStrategy {
+    static let customISO8601 = custom {
+        let container = try $0.singleValueContainer()
+        let string = try container.decode(String.self)
+        if let date = Formatter.iso8601.date(from: string) ?? Formatter.iso8601noFS.date(from: string) {
+            return date
+        }
+        throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date: \(string)")
+    }
+}
+
+extension JSONDecoder {
+    static var telemetryDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        dateFormatter.locale = Locale(identifier: "en_US")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        return decoder
+    }()
+
+    static var druidDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .customISO8601
+        return decoder
+    }()
+}
+
+extension JSONEncoder {
+    static var telemetryEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        dateFormatter.locale = Locale(identifier: "en_US")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        encoder.dateEncodingStrategy = .formatted(dateFormatter)
+        return encoder
+    }()
+}
+
+extension Data {
+    var prettyPrintedJSONString: NSString? { /// NSString gives us a nice sanitized debugDescription
+        guard let object = try? JSONSerialization.jsonObject(with: self, options: []),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+              let prettyPrintedString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) else { return nil }
+
+        return prettyPrintedString
+    }
+}

--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -39,12 +39,11 @@ class SignalCache {
     /// (e.g. sending them to a server) you should reinsert them into the cache with the `push` function.
     func pop() -> [SignalPostBody] {
         pthread_mutex_lock(&mutex)
+        defer { pthread_mutex_unlock(&mutex) }
         
         let sliceSize = min(maximumNumberOfSignalsToPopAtOnce, cachedSignals.count)
         let poppedSignals = cachedSignals[..<sliceSize]
         cachedSignals.removeFirst(sliceSize)
-        
-        pthread_mutex_unlock(&mutex)
         
         return Array(poppedSignals)
     }

--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -1,0 +1,51 @@
+//
+//  SignalCache.swift
+//
+//
+//  Created by Daniel Jilg on 22.06.21.
+//
+
+import Foundation
+
+/// A local cache for signals to be sent to the AppTelemetry ingestion service
+///
+/// This class tries to be thread safe, with mutexes being managed in all push and pop functions.
+///
+/// There is no guarantee that Signals come out in the same order you put them in. This shouldn't matter though,
+/// since all Signals automatically get a `receivedAt` property with a date, allowing the server to reorder them
+/// correctly.
+class SignalCache {
+    private var cachedSignals: [SignalPostBody] = []
+    private let maximumNumberOfSignalsToPopAtOnce = 10
+    var mutex: pthread_mutex_t = pthread_mutex_t()
+
+    /// Insert a Signal into the cache
+    func push(_ signal: SignalPostBody) {
+        pthread_mutex_lock(&mutex)
+        cachedSignals.append(signal)
+        pthread_mutex_unlock(&mutex)
+    }
+    
+    /// Insert a number of Signals into the cache
+    func push(_ signals: [SignalPostBody]) {
+        pthread_mutex_lock(&mutex)
+        cachedSignals.append(contentsOf: signals)
+        pthread_mutex_unlock(&mutex)
+    }
+
+    /// Remove a number of Signals from the cache and return them
+    ///
+    /// You should hold on to the signals returned by this function. If the action you are trying to do with them fails
+    /// (e.g. sending them to a server) you should reinsert them into the cache with the `push` function.
+    func pop() -> [SignalPostBody] {
+        pthread_mutex_lock(&mutex)
+        
+        let sliceSize = min(maximumNumberOfSignalsToPopAtOnce, cachedSignals.count)
+        let poppedSignals = cachedSignals[..<sliceSize]
+        cachedSignals.removeFirst(sliceSize)
+        
+        pthread_mutex_unlock(&mutex)
+        
+        return Array(poppedSignals)
+    }
+}

--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -22,15 +22,17 @@ class SignalCache {
     /// Insert a Signal into the cache
     func push(_ signal: SignalPostBody) {
         pthread_mutex_lock(&mutex)
+        defer { pthread_mutex_unlock(&mutex) }
+        
         cachedSignals.append(signal)
-        pthread_mutex_unlock(&mutex)
     }
     
     /// Insert a number of Signals into the cache
     func push(_ signals: [SignalPostBody]) {
         pthread_mutex_lock(&mutex)
+        defer { pthread_mutex_unlock(&mutex) }
+        
         cachedSignals.append(contentsOf: signals)
-        pthread_mutex_unlock(&mutex)
     }
 
     /// Remove a number of Signals from the cache and return them

--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -9,14 +9,14 @@ import Foundation
 
 /// A local cache for signals to be sent to the AppTelemetry ingestion service
 ///
-/// This class tries to be thread safe, with mutexes being managed in all push and pop functions.
-///
 /// There is no guarantee that Signals come out in the same order you put them in. This shouldn't matter though,
 /// since all Signals automatically get a `receivedAt` property with a date, allowing the server to reorder them
 /// correctly.
+///
+/// Currently the cache is only in-memory. This will probably change in the near future.
 class SignalCache {
     private var cachedSignals: [SignalPostBody] = []
-    private let maximumNumberOfSignalsToPopAtOnce = 10
+    private let maximumNumberOfSignalsToPopAtOnce = 100
     let queue = DispatchQueue(label: "apptelemetry-signal-cache", attributes: .concurrent)
 
     /// Insert a Signal into the cache

--- a/Sources/TelemetryClient/SignalPostBody.swift
+++ b/Sources/TelemetryClient/SignalPostBody.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by Daniel Jilg on 22.06.21.
+//
+
+import Foundation
+
+struct SignalPostBody: Codable, Equatable {
+    let receivedAt: Date
+    let type: String
+    let clientUser: String
+    let sessionID: String
+    let payload: [String: String]?
+}

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -133,7 +133,7 @@ public class TelemetryManager {
         urlRequest.httpMethod = "POST"
         urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        urlRequest.httpBody = try! JSONEncoder().encode(signalPostBody)
+        urlRequest.httpBody = try! JSONEncoder.telemetryEncoder.encode(signalPostBody)
 
         let task = URLSession.shared.dataTask(with: urlRequest, completionHandler: completionHandler)
         task.resume()
@@ -290,7 +290,7 @@ private extension TelemetryManager {
         #endif
     }
 
-    /// The target environment as reported by swift. Either "simulator", "macCatalyst" or
+    /// The target environment as reported by swift. Either "simulator", "macCatalyst" or "native".
     var targetEnvironment: String {
         #if targetEnvironment(simulator)
             return "simulator"

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -100,6 +100,7 @@ public class TelemetryManager {
             ].merging(additionalPayload, uniquingKeysWith: { _, last in last })
 
             let signalPostBody = SignalPostBody(
+                receivedAt: Date(),
                 type: "\(signalType)",
                 clientUser: sha256(str: clientUser ?? defaultUserIdentifier),
                 sessionID: configuration.sessionID.uuidString,
@@ -125,13 +126,6 @@ public class TelemetryManager {
     private static var initializedTelemetryManager: TelemetryManager?
 
     private let configuration: TelemetryManagerConfiguration
-
-    private struct SignalPostBody: Codable {
-        let type: String
-        let clientUser: String
-        let sessionID: String
-        let payload: [String: String]?
-    }
 }
 
 private extension TelemetryManager {

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -2,6 +2,11 @@
 import XCTest
 
 final class TelemetryClientTests: XCTestCase {
+    static var allTests = [
+        ("testExample", testExample),
+        ("testPushAndPop", testPushAndPop),
+    ]
+    
     func testExample() {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
@@ -14,8 +19,45 @@ final class TelemetryClientTests: XCTestCase {
         TelemetryManager.send("userLoggedIn", for: "email")
         TelemetryManager.send("databaseUpdated", with: ["numberOfDatabaseEntries": "3831"])
     }
-
-    static var allTests = [
-        ("testExample", testExample),
-    ]
+    
+    func testPushAndPop() {
+        let signalCache = SignalCache()
+        
+        let signals: [SignalPostBody] = [
+            .init(receivedAt: Date(), type: "01", clientUser: "01", sessionID: "01", payload: nil),
+            .init(receivedAt: Date(), type: "02", clientUser: "02", sessionID: "02", payload: nil),
+            .init(receivedAt: Date(), type: "03", clientUser: "03", sessionID: "03", payload: nil),
+            .init(receivedAt: Date(), type: "04", clientUser: "04", sessionID: "04", payload: nil),
+            .init(receivedAt: Date(), type: "05", clientUser: "05", sessionID: "05", payload: nil),
+            .init(receivedAt: Date(), type: "06", clientUser: "06", sessionID: "06", payload: nil),
+            .init(receivedAt: Date(), type: "07", clientUser: "07", sessionID: "07", payload: nil),
+            .init(receivedAt: Date(), type: "08", clientUser: "08", sessionID: "08", payload: nil),
+            .init(receivedAt: Date(), type: "09", clientUser: "09", sessionID: "09", payload: nil),
+            .init(receivedAt: Date(), type: "10", clientUser: "10", sessionID: "10", payload: nil),
+            .init(receivedAt: Date(), type: "11", clientUser: "11", sessionID: "11", payload: nil),
+            .init(receivedAt: Date(), type: "12", clientUser: "12", sessionID: "12", payload: nil),
+            .init(receivedAt: Date(), type: "13", clientUser: "13", sessionID: "13", payload: nil),
+            .init(receivedAt: Date(), type: "14", clientUser: "14", sessionID: "14", payload: nil),
+            .init(receivedAt: Date(), type: "15", clientUser: "15", sessionID: "15", payload: nil)
+        ]
+        
+        for signal in signals {
+            signalCache.push(signal)
+        }
+        
+        var allPoppedSignals: [SignalPostBody] = []
+        var poppedSignalsBatch: [SignalPostBody] = signalCache.pop()
+        while !poppedSignalsBatch.isEmpty {
+            allPoppedSignals.append(contentsOf: poppedSignalsBatch)
+            poppedSignalsBatch = signalCache.pop()
+        }
+        
+        XCTAssertEqual(signals.count, allPoppedSignals.count)
+        
+        allPoppedSignals.sort { lhs, rhs in
+            lhs.type < rhs.type
+        }
+        
+        XCTAssertEqual(signals, allPoppedSignals)
+    }
 }


### PR DESCRIPTION
This PR modifies the AppTelemetry client so that it will not immediately send signals to the server. Instead it will cache them locally, sending any accumulated signals in bulk every 10 seconds at the earliest.

Signals will be sent in groups of 100 instead of one-http-request-per-Signal. For apps that send many signals during a session, this will improve battery runtime. If you're sending 100 signals every 10 seconds, you're probably still doing something wrong though.

We retrieve signals from the cache, try to send them, and if that fails, reinsert them into the cache. This should hopefully ensure that signals can be re-sent if the device is unable to connect to the internet.

Right now, caching is only in-memory, meaning that if your app terminates, any unsent signals will be gone. However, this feature will be the basis for an on-disk-cache that will persist signals across app launches. I just want to get the mechanics of using the cache right before I implement the cache itself.

Comments are very much welcome! 