### PR TITLE
Added local and disk caching and test targets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
 /.build
 /Packages
-/*.xcodeproj
 xcuserdata/

--- a/ClientTester.xcodeproj/project.pbxproj
+++ b/ClientTester.xcodeproj/project.pbxproj
@@ -1,0 +1,1365 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 53;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		62033B7C268633C600339CC4 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6215FE882685FF7900EE27A1 /* Signal.swift */; };
+		62033B7E268633C600339CC4 /* TelemetryClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6215FE822685FF7900EE27A1 /* TelemetryClient.swift */; };
+		62033B7F268633C600339CC4 /* SignalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6215FE872685FF7900EE27A1 /* SignalCache.swift */; };
+		62033B80268633C600339CC4 /* SignalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6215FE842685FF7900EE27A1 /* SignalManager.swift */; };
+		620A69142689D90A003F4384 /* JSONFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620A69132689D90A003F4384 /* JSONFormatting.swift */; };
+		620A69152689D90A003F4384 /* JSONFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620A69132689D90A003F4384 /* JSONFormatting.swift */; };
+		6215FE892685FF7900EE27A1 /* TelemetryClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6215FE822685FF7900EE27A1 /* TelemetryClient.swift */; };
+		6215FE8B2685FF7900EE27A1 /* SignalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6215FE842685FF7900EE27A1 /* SignalManager.swift */; };
+		6215FE8E2685FF7900EE27A1 /* SignalCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6215FE872685FF7900EE27A1 /* SignalCache.swift */; };
+		6215FE8F2685FF7900EE27A1 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6215FE882685FF7900EE27A1 /* Signal.swift */; };
+		622CA16A2684C5C900AAEC27 /* ClientTesterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56EE1B2682052400049E66 /* ClientTesterApp.swift */; };
+		622CA16B2684C5CD00AAEC27 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56EE1D2682052400049E66 /* ContentView.swift */; };
+		622CA16C2684C5E800AAEC27 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B56EE1F2682052500049E66 /* Assets.xcassets */; };
+		62990772268633870040C1C5 /* TelemetryClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 6215FE852685FF7900EE27A1 /* TelemetryClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		62A8C86F268617C60002F634 /* TelemetryClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6215FE6F2685FCAD00EE27A1 /* TelemetryClient.framework */; };
+		62A8C870268617C60002F634 /* TelemetryClient.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6215FE6F2685FCAD00EE27A1 /* TelemetryClient.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		62A8C874268617E20002F634 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56EE1D2682052400049E66 /* ContentView.swift */; };
+		62A8C875268617EE0002F634 /* ClientTesterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56EE1B2682052400049E66 /* ClientTesterApp.swift */; };
+		62A8C876268618AB0002F634 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B56EE1F2682052500049E66 /* Assets.xcassets */; };
+		62AE9D3B26863B1F0025A26C /* ClientTester-watchOS WatchKit App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 62AE9D3A26863B1F0025A26C /* ClientTester-watchOS WatchKit App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		62AE9D4726863B210025A26C /* ClientTester-watchOS WatchKit Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 62AE9D4626863B210025A26C /* ClientTester-watchOS WatchKit Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		62AE9D6226863B6A0025A26C /* TelemetryClient_WatchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 629907662686326E0040C1C5 /* TelemetryClient_WatchOS.framework */; };
+		62AE9D6326863B6A0025A26C /* TelemetryClient_WatchOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 629907662686326E0040C1C5 /* TelemetryClient_WatchOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		62AE9D6726863B890025A26C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56EE1D2682052400049E66 /* ContentView.swift */; };
+		62AE9D6826863B930025A26C /* ClientTesterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56EE1B2682052400049E66 /* ClientTesterApp.swift */; };
+		62AE9D6926863BF70025A26C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B56EE1F2682052500049E66 /* Assets.xcassets */; };
+		62BBC01A268630C100351343 /* TelemetryClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 6215FE852685FF7900EE27A1 /* TelemetryClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		62C6531A2687B32B00109533 /* ClientTesterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56EE1B2682052400049E66 /* ClientTesterApp.swift */; };
+		62C6531B2687B33300109533 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B56EE1D2682052400049E66 /* ContentView.swift */; };
+		62C6531C2687B34400109533 /* TelemetryClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6215FE6F2685FCAD00EE27A1 /* TelemetryClient.framework */; };
+		62C6531D2687B34400109533 /* TelemetryClient.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6215FE6F2685FCAD00EE27A1 /* TelemetryClient.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		62C653212687B36200109533 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B56EE1F2682052500049E66 /* Assets.xcassets */; };
+		62E32CA226862E080097EE44 /* TelemetryClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6215FE6F2685FCAD00EE27A1 /* TelemetryClient.framework */; };
+		62E32CA326862E080097EE44 /* TelemetryClient.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6215FE6F2685FCAD00EE27A1 /* TelemetryClient.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		62EE317B26863C6900E06CE6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B56EE1F2682052500049E66 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		62A8C871268617C60002F634 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2B56EE102682052400049E66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6215FE6E2685FCAD00EE27A1;
+			remoteInfo = TelemetryClient;
+		};
+		62AE9D3C26863B1F0025A26C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2B56EE102682052400049E66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 62AE9D3926863B1F0025A26C;
+			remoteInfo = "SwiftClientTester-watchOS WatchKit App";
+		};
+		62AE9D4826863B210025A26C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2B56EE102682052400049E66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 62AE9D4526863B210025A26C;
+			remoteInfo = "SwiftClientTester-watchOS WatchKit Extension";
+		};
+		62AE9D6426863B6A0025A26C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2B56EE102682052400049E66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 629907652686326E0040C1C5;
+			remoteInfo = TelemetryClient_WatchOS;
+		};
+		62C6531E2687B34400109533 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2B56EE102682052400049E66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6215FE6E2685FCAD00EE27A1;
+			remoteInfo = TelemetryClient;
+		};
+		62E32CA426862E080097EE44 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2B56EE102682052400049E66 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6215FE6E2685FCAD00EE27A1;
+			remoteInfo = TelemetryClient;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		62A8C873268617C60002F634 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				62A8C870268617C60002F634 /* TelemetryClient.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62AE9D5A26863B220025A26C /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				62AE9D4726863B210025A26C /* ClientTester-watchOS WatchKit Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62AE9D5E26863B220025A26C /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				62AE9D3B26863B1F0025A26C /* ClientTester-watchOS WatchKit App.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62AE9D6626863B6A0025A26C /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				62AE9D6326863B6A0025A26C /* TelemetryClient_WatchOS.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62C653202687B34400109533 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				62C6531D2687B34400109533 /* TelemetryClient.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62E32C9E26862D180097EE44 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62E32CA626862E090097EE44 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				62E32CA326862E080097EE44 /* TelemetryClient.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		2B56EE1B2682052400049E66 /* ClientTesterApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTesterApp.swift; sourceTree = "<group>"; };
+		2B56EE1D2682052400049E66 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		2B56EE1F2682052500049E66 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		2B56EE30268480FE00049E66 /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
+		620A69132689D90A003F4384 /* JSONFormatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONFormatting.swift; sourceTree = "<group>"; };
+		6215FE6F2685FCAD00EE27A1 /* TelemetryClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TelemetryClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6215FE822685FF7900EE27A1 /* TelemetryClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TelemetryClient.swift; path = Sources/TelemetryClient/TelemetryClient.swift; sourceTree = SOURCE_ROOT; };
+		6215FE842685FF7900EE27A1 /* SignalManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignalManager.swift; path = Sources/TelemetryClient/SignalManager.swift; sourceTree = SOURCE_ROOT; };
+		6215FE852685FF7900EE27A1 /* TelemetryClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TelemetryClient.h; path = Sources/TelemetryClient/TelemetryClient.h; sourceTree = SOURCE_ROOT; };
+		6215FE872685FF7900EE27A1 /* SignalCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignalCache.swift; path = Sources/TelemetryClient/SignalCache.swift; sourceTree = SOURCE_ROOT; };
+		6215FE882685FF7900EE27A1 /* Signal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Signal.swift; path = Sources/TelemetryClient/Signal.swift; sourceTree = SOURCE_ROOT; };
+		622CA1552684C58E00AAEC27 /* ClientTester-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ClientTester-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		622CA1602684C59000AAEC27 /* iOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "iOS-Info.plist"; sourceTree = "<group>"; };
+		629907662686326E0040C1C5 /* TelemetryClient_WatchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TelemetryClient_WatchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		62A8C85F268617860002F634 /* ClientTester-macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ClientTester-macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		62A8C86A268617880002F634 /* macOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "macOS-Info.plist"; sourceTree = "<group>"; };
+		62A8C86B268617880002F634 /* ClientTester_macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ClientTester_macOS.entitlements; sourceTree = "<group>"; };
+		62AE9D3726863B1E0025A26C /* ClientTester-watchOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ClientTester-watchOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		62AE9D3A26863B1F0025A26C /* ClientTester-watchOS WatchKit App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ClientTester-watchOS WatchKit App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		62AE9D4126863B210025A26C /* watchOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "watchOS-Info.plist"; sourceTree = "<group>"; };
+		62AE9D4626863B210025A26C /* ClientTester-watchOS WatchKit Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "ClientTester-watchOS WatchKit Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		62AE9D5626863B220025A26C /* watchOS-Extension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "watchOS-Extension-Info.plist"; sourceTree = "<group>"; };
+		62C6530B2687B2F400109533 /* ClientTester-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ClientTester-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		62C653162687B2F500109533 /* tvOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "tvOS-Info.plist"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6215FE6C2685FCAD00EE27A1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		622CA1522684C58E00AAEC27 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62E32CA226862E080097EE44 /* TelemetryClient.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		629907632686326E0040C1C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62A8C85C268617860002F634 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62A8C86F268617C60002F634 /* TelemetryClient.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62AE9D4326863B210025A26C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62AE9D6226863B6A0025A26C /* TelemetryClient_WatchOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62C653082687B2F400109533 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62C6531C2687B34400109533 /* TelemetryClient.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2B56EE0F2682052400049E66 = {
+			isa = PBXGroup;
+			children = (
+				2B56EE1A2682052400049E66 /* ClientTester */,
+				6215FE702685FCAD00EE27A1 /* TelemetryClient */,
+				2B56EE192682052400049E66 /* Products */,
+				2B56EE2F268480FE00049E66 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		2B56EE192682052400049E66 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				622CA1552684C58E00AAEC27 /* ClientTester-iOS.app */,
+				6215FE6F2685FCAD00EE27A1 /* TelemetryClient.framework */,
+				62A8C85F268617860002F634 /* ClientTester-macOS.app */,
+				629907662686326E0040C1C5 /* TelemetryClient_WatchOS.framework */,
+				62AE9D3726863B1E0025A26C /* ClientTester-watchOS.app */,
+				62AE9D3A26863B1F0025A26C /* ClientTester-watchOS WatchKit App.app */,
+				62AE9D4626863B210025A26C /* ClientTester-watchOS WatchKit Extension.appex */,
+				62C6530B2687B2F400109533 /* ClientTester-tvOS.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		2B56EE1A2682052400049E66 /* ClientTester */ = {
+			isa = PBXGroup;
+			children = (
+				622CA1602684C59000AAEC27 /* iOS-Info.plist */,
+				62A8C86A268617880002F634 /* macOS-Info.plist */,
+				62AE9D4126863B210025A26C /* watchOS-Info.plist */,
+				62AE9D5626863B220025A26C /* watchOS-Extension-Info.plist */,
+				62C653162687B2F500109533 /* tvOS-Info.plist */,
+				62A8C86B268617880002F634 /* ClientTester_macOS.entitlements */,
+				2B56EE1B2682052400049E66 /* ClientTesterApp.swift */,
+				2B56EE1D2682052400049E66 /* ContentView.swift */,
+				2B56EE1F2682052500049E66 /* Assets.xcassets */,
+			);
+			path = ClientTester;
+			sourceTree = "<group>";
+		};
+		2B56EE2F268480FE00049E66 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2B56EE30268480FE00049E66 /* NetworkExtension.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6215FE702685FCAD00EE27A1 /* TelemetryClient */ = {
+			isa = PBXGroup;
+			children = (
+				6215FE852685FF7900EE27A1 /* TelemetryClient.h */,
+				6215FE822685FF7900EE27A1 /* TelemetryClient.swift */,
+				6215FE882685FF7900EE27A1 /* Signal.swift */,
+				6215FE842685FF7900EE27A1 /* SignalManager.swift */,
+				6215FE872685FF7900EE27A1 /* SignalCache.swift */,
+				620A69132689D90A003F4384 /* JSONFormatting.swift */,
+			);
+			name = TelemetryClient;
+			path = Sources/TelemetryClient;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		6215FE6A2685FCAD00EE27A1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62BBC01A268630C100351343 /* TelemetryClient.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		629907612686326E0040C1C5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62990772268633870040C1C5 /* TelemetryClient.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		6215FE6E2685FCAD00EE27A1 /* TelemetryClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6215FE742685FCAD00EE27A1 /* Build configuration list for PBXNativeTarget "TelemetryClient" */;
+			buildPhases = (
+				6215FE6A2685FCAD00EE27A1 /* Headers */,
+				6215FE6B2685FCAD00EE27A1 /* Sources */,
+				6215FE6C2685FCAD00EE27A1 /* Frameworks */,
+				6215FE6D2685FCAD00EE27A1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TelemetryClient;
+			productName = TelemetryClient;
+			productReference = 6215FE6F2685FCAD00EE27A1 /* TelemetryClient.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		622CA1542684C58E00AAEC27 /* ClientTester-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 622CA1612684C59000AAEC27 /* Build configuration list for PBXNativeTarget "ClientTester-iOS" */;
+			buildPhases = (
+				622CA16E2684C71300AAEC27 /* Check TODO, FIXME & XXX */,
+				622CA1512684C58E00AAEC27 /* Sources */,
+				622CA1522684C58E00AAEC27 /* Frameworks */,
+				622CA1532684C58E00AAEC27 /* Resources */,
+				62E32C9E26862D180097EE44 /* Embed Watch Content */,
+				62E32CA626862E090097EE44 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				62E32CA526862E080097EE44 /* PBXTargetDependency */,
+			);
+			name = "ClientTester-iOS";
+			productName = "SwiftClientTester-iOS";
+			productReference = 622CA1552684C58E00AAEC27 /* ClientTester-iOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		629907652686326E0040C1C5 /* TelemetryClient_WatchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 629907712686326E0040C1C5 /* Build configuration list for PBXNativeTarget "TelemetryClient_WatchOS" */;
+			buildPhases = (
+				629907612686326E0040C1C5 /* Headers */,
+				629907622686326E0040C1C5 /* Sources */,
+				629907632686326E0040C1C5 /* Frameworks */,
+				629907642686326E0040C1C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TelemetryClient_WatchOS;
+			productName = TelemetryClient_WatchOS;
+			productReference = 629907662686326E0040C1C5 /* TelemetryClient_WatchOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		62A8C85E268617860002F634 /* ClientTester-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 62A8C86C268617880002F634 /* Build configuration list for PBXNativeTarget "ClientTester-macOS" */;
+			buildPhases = (
+				62EE317C26863CFB00E06CE6 /* Check TODO, FIXME & XXX */,
+				62A8C85B268617860002F634 /* Sources */,
+				62A8C85C268617860002F634 /* Frameworks */,
+				62A8C85D268617860002F634 /* Resources */,
+				62A8C873268617C60002F634 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				62A8C872268617C60002F634 /* PBXTargetDependency */,
+			);
+			name = "ClientTester-macOS";
+			productName = "SwiftClientTester-macOS";
+			productReference = 62A8C85F268617860002F634 /* ClientTester-macOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		62AE9D3626863B1E0025A26C /* ClientTester-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 62AE9D5F26863B220025A26C /* Build configuration list for PBXNativeTarget "ClientTester-watchOS" */;
+			buildPhases = (
+				62AE9D3526863B1E0025A26C /* Resources */,
+				62AE9D5E26863B220025A26C /* Embed Watch Content */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				62AE9D3D26863B1F0025A26C /* PBXTargetDependency */,
+			);
+			name = "ClientTester-watchOS";
+			productName = "SwiftClientTester-watchOS";
+			productReference = 62AE9D3726863B1E0025A26C /* ClientTester-watchOS.app */;
+			productType = "com.apple.product-type.application.watchapp2-container";
+		};
+		62AE9D3926863B1F0025A26C /* ClientTester-watchOS WatchKit App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 62AE9D5B26863B220025A26C /* Build configuration list for PBXNativeTarget "ClientTester-watchOS WatchKit App" */;
+			buildPhases = (
+				62AE9D3826863B1F0025A26C /* Resources */,
+				62AE9D5A26863B220025A26C /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				62AE9D4926863B210025A26C /* PBXTargetDependency */,
+			);
+			name = "ClientTester-watchOS WatchKit App";
+			productName = "SwiftClientTester-watchOS WatchKit App";
+			productReference = 62AE9D3A26863B1F0025A26C /* ClientTester-watchOS WatchKit App.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		62AE9D4526863B210025A26C /* ClientTester-watchOS WatchKit Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 62AE9D5726863B220025A26C /* Build configuration list for PBXNativeTarget "ClientTester-watchOS WatchKit Extension" */;
+			buildPhases = (
+				62EE317D26863D0E00E06CE6 /* Check TODO, FIXME & XXX */,
+				62AE9D4226863B210025A26C /* Sources */,
+				62AE9D4326863B210025A26C /* Frameworks */,
+				62AE9D4426863B210025A26C /* Resources */,
+				62AE9D6626863B6A0025A26C /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				62AE9D6526863B6A0025A26C /* PBXTargetDependency */,
+			);
+			name = "ClientTester-watchOS WatchKit Extension";
+			productName = "SwiftClientTester-watchOS WatchKit Extension";
+			productReference = 62AE9D4626863B210025A26C /* ClientTester-watchOS WatchKit Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
+		62C6530A2687B2F400109533 /* ClientTester-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 62C653172687B2F500109533 /* Build configuration list for PBXNativeTarget "ClientTester-tvOS" */;
+			buildPhases = (
+				62C653072687B2F400109533 /* Sources */,
+				62C653082687B2F400109533 /* Frameworks */,
+				62C653092687B2F400109533 /* Resources */,
+				62C653202687B34400109533 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				62C6531F2687B34400109533 /* PBXTargetDependency */,
+			);
+			name = "ClientTester-tvOS";
+			productName = "SwiftClientTester-tvOS";
+			productReference = 62C6530B2687B2F400109533 /* ClientTester-tvOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2B56EE102682052400049E66 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1250;
+				LastUpgradeCheck = 1300;
+				TargetAttributes = {
+					6215FE6E2685FCAD00EE27A1 = {
+						CreatedOnToolsVersion = 12.5;
+						LastSwiftMigration = 1250;
+					};
+					622CA1542684C58E00AAEC27 = {
+						CreatedOnToolsVersion = 12.5;
+					};
+					629907652686326E0040C1C5 = {
+						CreatedOnToolsVersion = 12.5;
+					};
+					62A8C85E268617860002F634 = {
+						CreatedOnToolsVersion = 12.5;
+					};
+					62AE9D3626863B1E0025A26C = {
+						CreatedOnToolsVersion = 12.5;
+					};
+					62AE9D3926863B1F0025A26C = {
+						CreatedOnToolsVersion = 12.5;
+					};
+					62AE9D4526863B210025A26C = {
+						CreatedOnToolsVersion = 12.5;
+					};
+					62C6530A2687B2F400109533 = {
+						CreatedOnToolsVersion = 12.5;
+					};
+				};
+			};
+			buildConfigurationList = 2B56EE132682052400049E66 /* Build configuration list for PBXProject "ClientTester" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2B56EE0F2682052400049E66;
+			packageReferences = (
+			);
+			productRefGroup = 2B56EE192682052400049E66 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6215FE6E2685FCAD00EE27A1 /* TelemetryClient */,
+				629907652686326E0040C1C5 /* TelemetryClient_WatchOS */,
+				622CA1542684C58E00AAEC27 /* ClientTester-iOS */,
+				62A8C85E268617860002F634 /* ClientTester-macOS */,
+				62C6530A2687B2F400109533 /* ClientTester-tvOS */,
+				62AE9D3626863B1E0025A26C /* ClientTester-watchOS */,
+				62AE9D3926863B1F0025A26C /* ClientTester-watchOS WatchKit App */,
+				62AE9D4526863B210025A26C /* ClientTester-watchOS WatchKit Extension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6215FE6D2685FCAD00EE27A1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		622CA1532684C58E00AAEC27 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				622CA16C2684C5E800AAEC27 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		629907642686326E0040C1C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62A8C85D268617860002F634 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62A8C876268618AB0002F634 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62AE9D3526863B1E0025A26C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62AE9D3826863B1F0025A26C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62EE317B26863C6900E06CE6 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62AE9D4426863B210025A26C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62AE9D6926863BF70025A26C /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62C653092687B2F400109533 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62C653212687B36200109533 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		622CA16E2684C71300AAEC27 /* Check TODO, FIXME & XXX */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check TODO, FIXME & XXX";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "TAGS=\"TODO:|FIXME:|XXX:|\\?\\?\\?:|\\!\\!\\!:\"\nERRORTAG=\"ERROR:\"\nfind \"${SRCROOT}\" \\( -name \"*.h\" -or -name \"*.m\" -or -name \"*.swift\" \\) -not -path \"${SRCROOT}/Carthage/*\" -print0 | xargs -0 egrep --with-filename --line-number --only-matching \"($TAGS).*\\$|($ERRORTAG).*\\$\" | perl -p -e \"s/($TAGS)/ warning: \\$1/\" | perl -p -e \"s/($ERRORTAG)/ error: \\$1/\"\n";
+		};
+		62EE317C26863CFB00E06CE6 /* Check TODO, FIXME & XXX */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check TODO, FIXME & XXX";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "TAGS=\"TODO:|FIXME:|XXX:|\\?\\?\\?:|\\!\\!\\!:\"\nERRORTAG=\"ERROR:\"\nfind \"${SRCROOT}\" \\( -name \"*.h\" -or -name \"*.m\" -or -name \"*.swift\" \\) -not -path \"${SRCROOT}/Carthage/*\" -print0 | xargs -0 egrep --with-filename --line-number --only-matching \"($TAGS).*\\$|($ERRORTAG).*\\$\" | perl -p -e \"s/($TAGS)/ warning: \\$1/\" | perl -p -e \"s/($ERRORTAG)/ error: \\$1/\"\n";
+		};
+		62EE317D26863D0E00E06CE6 /* Check TODO, FIXME & XXX */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check TODO, FIXME & XXX";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "TAGS=\"TODO:|FIXME:|XXX:|\\?\\?\\?:|\\!\\!\\!:\"\nERRORTAG=\"ERROR:\"\nfind \"${SRCROOT}\" \\( -name \"*.h\" -or -name \"*.m\" -or -name \"*.swift\" \\) -not -path \"${SRCROOT}/Carthage/*\" -print0 | xargs -0 egrep --with-filename --line-number --only-matching \"($TAGS).*\\$|($ERRORTAG).*\\$\" | perl -p -e \"s/($TAGS)/ warning: \\$1/\" | perl -p -e \"s/($ERRORTAG)/ error: \\$1/\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6215FE6B2685FCAD00EE27A1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6215FE892685FF7900EE27A1 /* TelemetryClient.swift in Sources */,
+				6215FE8F2685FF7900EE27A1 /* Signal.swift in Sources */,
+				620A69142689D90A003F4384 /* JSONFormatting.swift in Sources */,
+				6215FE8E2685FF7900EE27A1 /* SignalCache.swift in Sources */,
+				6215FE8B2685FF7900EE27A1 /* SignalManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		622CA1512684C58E00AAEC27 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				622CA16A2684C5C900AAEC27 /* ClientTesterApp.swift in Sources */,
+				622CA16B2684C5CD00AAEC27 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		629907622686326E0040C1C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62033B7E268633C600339CC4 /* TelemetryClient.swift in Sources */,
+				62033B7F268633C600339CC4 /* SignalCache.swift in Sources */,
+				620A69152689D90A003F4384 /* JSONFormatting.swift in Sources */,
+				62033B80268633C600339CC4 /* SignalManager.swift in Sources */,
+				62033B7C268633C600339CC4 /* Signal.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62A8C85B268617860002F634 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62A8C875268617EE0002F634 /* ClientTesterApp.swift in Sources */,
+				62A8C874268617E20002F634 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62AE9D4226863B210025A26C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62AE9D6826863B930025A26C /* ClientTesterApp.swift in Sources */,
+				62AE9D6726863B890025A26C /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62C653072687B2F400109533 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62C6531B2687B33300109533 /* ContentView.swift in Sources */,
+				62C6531A2687B32B00109533 /* ClientTesterApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		62A8C872268617C60002F634 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6215FE6E2685FCAD00EE27A1 /* TelemetryClient */;
+			targetProxy = 62A8C871268617C60002F634 /* PBXContainerItemProxy */;
+		};
+		62AE9D3D26863B1F0025A26C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 62AE9D3926863B1F0025A26C /* ClientTester-watchOS WatchKit App */;
+			targetProxy = 62AE9D3C26863B1F0025A26C /* PBXContainerItemProxy */;
+		};
+		62AE9D4926863B210025A26C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 62AE9D4526863B210025A26C /* ClientTester-watchOS WatchKit Extension */;
+			targetProxy = 62AE9D4826863B210025A26C /* PBXContainerItemProxy */;
+		};
+		62AE9D6526863B6A0025A26C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 629907652686326E0040C1C5 /* TelemetryClient_WatchOS */;
+			targetProxy = 62AE9D6426863B6A0025A26C /* PBXContainerItemProxy */;
+		};
+		62C6531F2687B34400109533 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6215FE6E2685FCAD00EE27A1 /* TelemetryClient */;
+			targetProxy = 62C6531E2687B34400109533 /* PBXContainerItemProxy */;
+		};
+		62E32CA526862E080097EE44 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6215FE6E2685FCAD00EE27A1 /* TelemetryClient */;
+			targetProxy = 62E32CA426862E080097EE44 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		2B56EE242682052500049E66 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VALIDATE_WORKSPACE = YES;
+			};
+			name = Debug;
+		};
+		2B56EE252682052500049E66 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_WORKSPACE = YES;
+			};
+			name = Release;
+		};
+		6215FE752685FCAD00EE27A1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "ClientTester/iOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.TelemetrySwiftClient.TelemetryClient;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx watchsimulator watchos";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				VALIDATE_WORKSPACE = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = Debug;
+		};
+		6215FE762685FCAD00EE27A1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "ClientTester/iOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.TelemetrySwiftClient.TelemetryClient;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx watchsimulator watchos";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				VALIDATE_PRODUCT = YES;
+				VALIDATE_WORKSPACE = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = Release;
+		};
+		622CA1622684C59000AAEC27 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "ClientTester/iOS-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		622CA1632684C59000AAEC27 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "ClientTester/iOS-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		6299076F2686326E0040C1C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "ClientTester/iOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.TelemetryClient-watchOS.TelemetryClient-WatchOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 4.2;
+			};
+			name = Debug;
+		};
+		629907702686326E0040C1C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "ClientTester/iOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.TelemetryClient-watchOS.TelemetryClient-WatchOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 4.2;
+			};
+			name = Release;
+		};
+		62A8C86D268617880002F634 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ClientTester/ClientTester_macOS.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "ClientTester/macOS-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		62A8C86E268617880002F634 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ClientTester/ClientTester_macOS.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "ClientTester/macOS-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		62AE9D5826863B220025A26C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "ClientTester/watchOS-Extension-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-watchOS.ClientTester-watchOS.watchkitapp.watchkitextension";
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 7.4;
+			};
+			name = Debug;
+		};
+		62AE9D5926863B220025A26C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "ClientTester/watchOS-Extension-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-watchOS.ClientTester-watchOS.watchkitapp.watchkitextension";
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 7.4;
+			};
+			name = Release;
+		};
+		62AE9D5C26863B220025A26C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				IBSC_MODULE = ClientTester_watchOS_WatchKit_Extension;
+				INFOPLIST_FILE = "ClientTester/watchOS-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-watchOS.ClientTester-watchOS.watchkitapp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 7.4;
+			};
+			name = Debug;
+		};
+		62AE9D5D26863B220025A26C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				IBSC_MODULE = ClientTester_watchOS_WatchKit_Extension;
+				INFOPLIST_FILE = "ClientTester/watchOS-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-watchOS.ClientTester-watchOS.watchkitapp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 7.4;
+			};
+			name = Release;
+		};
+		62AE9D6026863B220025A26C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-watchOS.ClientTester-watchOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		62AE9D6126863B220025A26C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-watchOS.ClientTester-watchOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		62C653182687B2F500109533 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "ClientTester/tvOS-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-tvOS.ClientTester-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 14.5;
+			};
+			name = Debug;
+		};
+		62C653192687B2F500109533 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "ClientTester/tvOS-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.breakthesystem.ClientTester-tvOS.ClientTester-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 14.5;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2B56EE132682052400049E66 /* Build configuration list for PBXProject "ClientTester" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2B56EE242682052500049E66 /* Debug */,
+				2B56EE252682052500049E66 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6215FE742685FCAD00EE27A1 /* Build configuration list for PBXNativeTarget "TelemetryClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6215FE752685FCAD00EE27A1 /* Debug */,
+				6215FE762685FCAD00EE27A1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		622CA1612684C59000AAEC27 /* Build configuration list for PBXNativeTarget "ClientTester-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				622CA1622684C59000AAEC27 /* Debug */,
+				622CA1632684C59000AAEC27 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		629907712686326E0040C1C5 /* Build configuration list for PBXNativeTarget "TelemetryClient_WatchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6299076F2686326E0040C1C5 /* Debug */,
+				629907702686326E0040C1C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		62A8C86C268617880002F634 /* Build configuration list for PBXNativeTarget "ClientTester-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				62A8C86D268617880002F634 /* Debug */,
+				62A8C86E268617880002F634 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		62AE9D5726863B220025A26C /* Build configuration list for PBXNativeTarget "ClientTester-watchOS WatchKit Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				62AE9D5826863B220025A26C /* Debug */,
+				62AE9D5926863B220025A26C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		62AE9D5B26863B220025A26C /* Build configuration list for PBXNativeTarget "ClientTester-watchOS WatchKit App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				62AE9D5C26863B220025A26C /* Debug */,
+				62AE9D5D26863B220025A26C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		62AE9D5F26863B220025A26C /* Build configuration list for PBXNativeTarget "ClientTester-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				62AE9D6026863B220025A26C /* Debug */,
+				62AE9D6126863B220025A26C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		62C653172687B2F500109533 /* Build configuration list for PBXNativeTarget "ClientTester-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				62C653182687B2F500109533 /* Debug */,
+				62C653192687B2F500109533 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2B56EE102682052400049E66 /* Project object */;
+}

--- a/ClientTester.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ClientTester.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:/Users/darrenjones/Desktop/SwiftClientTester/ClientTester.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ClientTester.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ClientTester.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ClientTester.xcodeproj/xcshareddata/xcschemes/SwiftClientTester-iOS.xcscheme
+++ b/ClientTester.xcodeproj/xcshareddata/xcschemes/SwiftClientTester-iOS.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "622CA1542684C58E00AAEC27"
+               BuildableName = "ClientTester-iOS.app"
+               BlueprintName = "ClientTester-iOS"
+               ReferencedContainer = "container:ClientTester.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "622CA1542684C58E00AAEC27"
+            BuildableName = "ClientTester-iOS.app"
+            BlueprintName = "ClientTester-iOS"
+            ReferencedContainer = "container:ClientTester.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "622CA1542684C58E00AAEC27"
+            BuildableName = "ClientTester-iOS.app"
+            BlueprintName = "ClientTester-iOS"
+            ReferencedContainer = "container:ClientTester.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ClientTester.xcodeproj/xcshareddata/xcschemes/SwiftClientTester-macOS.xcscheme
+++ b/ClientTester.xcodeproj/xcshareddata/xcschemes/SwiftClientTester-macOS.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "62A8C85E268617860002F634"
+               BuildableName = "ClientTester-macOS.app"
+               BlueprintName = "ClientTester-macOS"
+               ReferencedContainer = "container:ClientTester.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "62A8C85E268617860002F634"
+            BuildableName = "ClientTester-macOS.app"
+            BlueprintName = "ClientTester-macOS"
+            ReferencedContainer = "container:ClientTester.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "62A8C85E268617860002F634"
+            BuildableName = "ClientTester-macOS.app"
+            BlueprintName = "ClientTester-macOS"
+            ReferencedContainer = "container:ClientTester.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ClientTester.xcodeproj/xcshareddata/xcschemes/TelemetryClient.xcscheme
+++ b/ClientTester.xcodeproj/xcshareddata/xcschemes/TelemetryClient.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6215FE6E2685FCAD00EE27A1"
+               BuildableName = "TelemetryClient.framework"
+               BlueprintName = "TelemetryClient"
+               ReferencedContainer = "container:ClientTester.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6215FE6E2685FCAD00EE27A1"
+            BuildableName = "TelemetryClient.framework"
+            BlueprintName = "TelemetryClient"
+            ReferencedContainer = "container:ClientTester.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ClientTester.xcodeproj/xcshareddata/xcschemes/TelemetryClient_WatchOS.xcscheme
+++ b/ClientTester.xcodeproj/xcshareddata/xcschemes/TelemetryClient_WatchOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "629907652686326E0040C1C5"
+               BuildableName = "TelemetryClient_WatchOS.framework"
+               BlueprintName = "TelemetryClient_WatchOS"
+               ReferencedContainer = "container:ClientTester.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "629907652686326E0040C1C5"
+            BuildableName = "TelemetryClient_WatchOS.framework"
+            BlueprintName = "TelemetryClient_WatchOS"
+            ReferencedContainer = "container:ClientTester.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ClientTester/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/ClientTester/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ClientTester/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ClientTester/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ClientTester/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ClientTester/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ClientTester/Assets.xcassets/Contents.json
+++ b/ClientTester/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ClientTester/ClientTesterApp.swift
+++ b/ClientTester/ClientTesterApp.swift
@@ -1,0 +1,33 @@
+//
+//  SwiftClientTesterApp.swift
+//  SwiftClientTester
+//
+//  Created by Daniel Jilg on 22.06.21.
+//
+
+import SwiftUI
+#if os(watchOS)
+    import TelemetryClient_WatchOS
+#else
+    import TelemetryClient
+#endif
+
+@main
+struct SwiftClientTesterApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+    
+    init() {
+        let configuration = TelemetryManagerConfiguration(
+            appID: "FA469AE1-1D1B-419D-B74C-0748C0325AFC"
+        )
+        configuration.telemetryAllowDebugBuilds = true
+        configuration.showDebugLogs = true
+        TelemetryManager.initialize(with: configuration)
+
+        TelemetryManager.send("applicationDidFinishLaunching", with: ["test":"test", "test2":"test2"])
+    }
+}

--- a/ClientTester/ClientTester_macOS.entitlements
+++ b/ClientTester/ClientTester_macOS.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/ClientTester/ContentView.swift
+++ b/ClientTester/ContentView.swift
@@ -1,0 +1,33 @@
+//
+//  ContentView.swift
+//  SwiftClientTester
+//
+//  Created by Daniel Jilg on 22.06.21.
+//
+
+import SwiftUI
+#if os(watchOS)
+    import TelemetryClient_WatchOS
+#else
+    import TelemetryClient
+#endif
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Text("Push this button to send 100 Boops!")
+            Button("100x Boop") {
+                for x in 0 ..< 100 {
+                    TelemetryManager.send("boop", with: ["test":"\(x)"])
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/ClientTester/Package.swift
+++ b/ClientTester/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+// Simply by having this Package.swift file here, it stops the demo/test projects showing up when opening the main Package.swift
+import PackageDescription
+
+let package = Package(
+    name: "TelemetryClient_SwiftClientTester"
+)

--- a/ClientTester/iOS-Info.plist
+++ b/ClientTester/iOS-Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/ClientTester/macOS-Info.plist
+++ b/ClientTester/macOS-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+</dict>
+</plist>

--- a/ClientTester/tvOS-Info.plist
+++ b/ClientTester/tvOS-Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Automatic</string>
+</dict>
+</plist>

--- a/ClientTester/watchOS-Extension-Info.plist
+++ b/ClientTester/watchOS-Extension-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ClientTester-watchOS WatchKit Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>org.breakthesystem.ClientTester-watchOS.ClientTester-watchOS.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+	<key>WKWatchOnly</key>
+	<true/>
+</dict>
+</plist>

--- a/ClientTester/watchOS-Info.plist
+++ b/ClientTester/watchOS-Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ClientTester-watchOS WatchKit App</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,12 @@ import PackageDescription
 
 let package = Package(
     name: "TelemetryClient",
+    platforms: [
+        .macOS(.v10_13),
+        .iOS(.v12),
+        .watchOS(.v4),
+        .tvOS(.v9)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
@@ -21,11 +27,13 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "TelemetryClient",
-            dependencies: []
+            dependencies: [],
+            exclude: ["SwiftClientTester"]
         ),
         .testTarget(
             name: "TelemetryClientTests",
-            dependencies: ["TelemetryClient"]
-        ),
+            dependencies: ["TelemetryClient"],
+            exclude: ["SwiftClientTester"]
+        )
     ]
 )

--- a/Sources/TelemetryClient/JSONFormatting.swift
+++ b/Sources/TelemetryClient/JSONFormatting.swift
@@ -1,0 +1,75 @@
+//
+//  JSONFormatting.swift
+//
+//
+//  Created by Daniel Jilg on 23.06.21.
+//
+
+import Foundation
+
+extension Formatter {
+    static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static let iso8601noFS = ISO8601DateFormatter()
+
+    static let iso8601dateOnly: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withFullDate]
+        return formatter
+    }()
+}
+
+extension JSONDecoder.DateDecodingStrategy {
+    static let customISO8601 = custom {
+        let container = try $0.singleValueContainer()
+        let string = try container.decode(String.self)
+        if let date = Formatter.iso8601.date(from: string) ?? Formatter.iso8601noFS.date(from: string) {
+            return date
+        }
+        throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date: \(string)")
+    }
+}
+
+extension JSONDecoder {
+    static var telemetryDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        dateFormatter.locale = Locale(identifier: "en_US")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        return decoder
+    }()
+
+    static var druidDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .customISO8601
+        return decoder
+    }()
+}
+
+extension JSONEncoder {
+    static var telemetryEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        dateFormatter.locale = Locale(identifier: "en_US")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        encoder.dateEncodingStrategy = .formatted(dateFormatter)
+        return encoder
+    }()
+}
+
+extension Data {
+    var prettyPrintedJSONString: NSString? { /// NSString gives us a nice sanitized debugDescription
+        guard let object = try? JSONSerialization.jsonObject(with: self, options: []),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+              let prettyPrintedString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) else { return nil }
+
+        return prettyPrintedString
+    }
+}

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -1,0 +1,206 @@
+//
+//  File.swift
+//  
+//
+//  Created by Daniel Jilg on 22.06.21.
+//
+
+import Foundation
+
+#if os(iOS)
+    import UIKit
+#elseif os(macOS)
+    import AppKit
+#elseif os(watchOS)
+    import WatchKit
+#elseif os(tvOS)
+    import TVUIKit
+#endif
+
+internal struct SignalPostBody: Codable, Equatable {
+    let receivedAt: Date
+    let type: String
+    let clientUser: String
+    let sessionID: String
+    let payload: [String: String]?
+}
+
+internal struct SignalPayload: Codable {
+    var platform: String = Self.platform
+    var systemVersion: String = Self.systemVersion
+    var appVersion: String = Self.appVersion
+    var buildNumber: String = Self.buildNumber
+    var isSimulator: String = "\(Self.isSimulator)"
+    var isTestFlight: String = "\(Self.isTestFlight)"
+    var isAppStore: String = "\(Self.isAppStore)"
+    var modelName: String = Self.modelName
+    var architecture: String = Self.architecture
+    var operatingSystem: String = Self.operatingSystem
+    var targetEnvironment: String = Self.targetEnvironment
+    var locale: String = Self.locale
+    
+    let additionalPayload: [String: String]
+}
+
+extension SignalPayload {
+    
+    /// Converts the `additionalPayload` to a `[String: String]` dictionary
+    func toDictionary() -> [String: String] {
+        // We need to convert the additionalPayload into new key/value pairs
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        do {
+            // Create a Dictionary
+            let jsonData = try encoder.encode(self)
+            var dict = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any]
+            // Remove the additionalPayload sub dictionary
+            dict?.removeValue(forKey: "additionalPayload")
+            // Add the additionalPayload as new key/value pairs
+            return dict?.merging(additionalPayload, uniquingKeysWith: { _, last in last }) as? [String: String] ?? [:]
+        }
+        catch
+        {
+            return [:]
+        }
+    }
+}
+
+// MARK: - Helpers
+extension SignalPayload {
+    
+    static var isSimulatorOrTestFlight: Bool {
+        (isSimulator || isTestFlight)
+    }
+
+    static var isSimulator: Bool {
+        #if targetEnvironment(simulator)
+            return true
+        #else
+            return false
+        #endif
+    }
+
+    static var isTestFlight: Bool {
+        guard let path = Bundle.main.appStoreReceiptURL?.path else {
+            return false
+        }
+        return path.contains("sandboxReceipt")
+    }
+
+    static var isAppStore: Bool {
+        !isSimulatorOrTestFlight
+    }
+
+    /// The operating system and its version
+    static var systemVersion: String {
+        #if os(macOS)
+            return "\(platform) \(ProcessInfo.processInfo.operatingSystemVersion.majorVersion).\(ProcessInfo.processInfo.operatingSystemVersion.minorVersion).\(ProcessInfo.processInfo.operatingSystemVersion.patchVersion)"
+        #elseif os(iOS)
+            return "\(platform)  \(UIDevice.current.systemVersion)"
+        #elseif os(watchOS)
+            return "\(platform) \(WKInterfaceDevice.current().systemVersion)"
+        #elseif os(tvOS)
+            return "\(platform) \(UIDevice.current.systemVersion)"
+        #else
+            return "\(platform)"
+        #endif
+    }
+
+    /// The Bundle Short Version String, as described in Info.plist
+    static var appVersion: String {
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        return appVersion ?? "0"
+    }
+
+    /// The Bundle Version String, as described in Info.plist
+    static var buildNumber: String {
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+        return buildNumber ?? "0"
+    }
+
+    /// The modelname as reported by systemInfo.machine
+    static var modelName: String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+        return identifier
+    }
+
+    /// The build architecture
+    static var architecture: String {
+        #if arch(x86_64)
+            return "x86_64"
+        #elseif arch(arm)
+            return "arm"
+        #elseif arch(arm64)
+            return "arm64"
+        #elseif arch(i386)
+            return "i386"
+        #elseif arch(powerpc64)
+            return "powerpc64"
+        #elseif arch(powerpc64le)
+            return "powerpc64le"
+        #elseif arch(s390x)
+            return "s390x"
+        #else
+            return "unknown"
+        #endif
+    }
+
+    /// The operating system as reported by Swift. Note that this will report catalyst apps and iOS apps running on
+    /// macOS as "iOS". See `platform` for an alternative.
+    static var operatingSystem: String {
+        #if os(macOS)
+            return "macOS"
+        #elseif os(iOS)
+            return "iOS"
+        #elseif os(watchOS)
+            return "watchOS"
+        #elseif os(tvOS)
+            return "tvOS"
+        #else
+            return "Unknown Operating System"
+        #endif
+    }
+
+    /// Based on the operating version reported by swift, but adding some smartness to better detect the actual
+    /// platform. Should correctly identify catalyst apps on macOS. Will probably not detect iOS apps running on
+    /// ARM based Macs.
+    static var platform: String {
+        #if os(macOS)
+            return "macOS"
+        #elseif os(iOS)
+            #if targetEnvironment(macCatalyst)
+                return "macCatalyst"
+            #else
+                return "iOS"
+            #endif
+        #elseif os(watchOS)
+            return "watchOS"
+        #elseif os(tvOS)
+            return "tvOS"
+        #else
+            return "Unknown Platform"
+        #endif
+    }
+
+    /// The target environment as reported by swift. Either "simulator", "macCatalyst" or
+    static var targetEnvironment: String {
+        #if targetEnvironment(simulator)
+            return "simulator"
+        #elseif targetEnvironment(macCatalyst)
+            return "macCatalyst"
+        #else
+            return "native"
+        #endif
+    }
+    
+    /// The locale identifier
+    static var locale: String {
+        return Locale.current.identifier
+    }
+}

--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -19,7 +19,8 @@ internal class SignalCache<T> where T: Codable {
     public var showDebugLogs: Bool = false
     
     private var cachedSignals: [T] = []
-    private let maximumNumberOfSignalsToPopAtOnce = 25
+    private let maximumNumberOfSignalsToPopAtOnce = 100
+    
     let queue = DispatchQueue(label: "apptelemetry-signal-cache", attributes: .concurrent)
     
     /// How many Signals are cached

--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -1,0 +1,118 @@
+//
+//  SignalCache.swift
+//
+//
+//  Created by Daniel Jilg on 22.06.21.
+//
+
+import Foundation
+
+/// A local cache for signals to be sent to the AppTelemetry ingestion service
+///
+/// There is no guarantee that Signals come out in the same order you put them in. This shouldn't matter though,
+/// since all Signals automatically get a `receivedAt` property with a date, allowing the server to reorder them
+/// correctly.
+///
+/// Currently the cache is only in-memory. This will probably change in the near future.
+internal class SignalCache<T> where T: Codable {
+    
+    public var showDebugLogs: Bool = false
+    
+    private var cachedSignals: [T] = []
+    private let maximumNumberOfSignalsToPopAtOnce = 25
+    let queue = DispatchQueue(label: "apptelemetry-signal-cache", attributes: .concurrent)
+    
+    /// How many Signals are cached
+    func count() -> Int {
+        queue.sync(flags: .barrier) {
+            return self.cachedSignals.count
+        }
+    }
+
+    /// Insert a Signal into the cache
+    func push(_ signal: T) {
+        queue.sync(flags: .barrier) {
+            self.cachedSignals.append(signal)
+        }
+    }
+
+    /// Insert a number of Signals into the cache
+    func push(_ signals: [T]) {
+        queue.sync(flags: .barrier) {
+            self.cachedSignals.append(contentsOf: signals)
+        }
+    }
+
+    /// Remove a number of Signals from the cache and return them
+    ///
+    /// You should hold on to the signals returned by this function. If the action you are trying to do with them fails
+    /// (e.g. sending them to a server) you should reinsert them into the cache with the `push` function.
+    func pop() -> [T] {
+        var poppedSignals: [T]!
+        
+        queue.sync {
+            let sliceSize = min(maximumNumberOfSignalsToPopAtOnce, cachedSignals.count)
+            poppedSignals = Array(cachedSignals[..<sliceSize])
+            cachedSignals.removeFirst(sliceSize)
+        }
+        
+        return poppedSignals
+    }
+    
+    private func fileURL() -> URL {
+        
+        let cacheFolderURL = try! FileManager.default.url(
+            for: .cachesDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+        
+        return cacheFolderURL.appendingPathComponent("telemetrysignalcache")
+    }
+    
+    /// Save the entire signal cache to disk
+    func backupCache() {
+        queue.sync {
+            if let data = try? JSONEncoder().encode(self.cachedSignals)
+            {
+                do {
+                    try data.write(to: fileURL())
+                    if (showDebugLogs) {
+                        print("Saved Telemetry cache \(data) of \(self.cachedSignals.count) signals")
+                    }
+                    // After saving the cache, we need to clear our local cache otherwise
+                    // it could get merged with the cache read back from disk later if
+                    // it's still in memory
+                    self.cachedSignals = []
+                } catch {
+                    print("Error saving Telemetry cache")
+                }
+            }
+        }
+    }
+    
+    /// Loads any previous signal cache from disk
+    init(showDebugLogs: Bool) {
+        self.showDebugLogs = showDebugLogs
+        
+        queue.sync {
+            if (showDebugLogs) {
+                print("Loading Telemetry cache from: \(fileURL())")
+            }
+            if let data = try? Data(contentsOf: fileURL())
+            {
+                // Loaded cache file, now delete it to stop it being loaded multiple times
+                try? FileManager.default.removeItem(at: fileURL())
+                
+                // Decode the data into a new cache
+                if let signals = try? JSONDecoder().decode([T].self, from: data) {
+                    if (showDebugLogs) {
+                        print("Loaded \(signals.count) signals")
+                    }
+                    self.cachedSignals = signals
+                }
+            }
+        }
+    }
+}

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -1,0 +1,323 @@
+//
+//  SignalManager.swift
+//  SwiftClientTester
+//
+//  Created by Darren Jones on 24/06/2021.
+//
+
+import CommonCrypto
+import Foundation
+
+#if os(iOS)
+    import UIKit
+#elseif os(macOS)
+    import AppKit
+#elseif os(watchOS)
+    import WatchKit
+#elseif os(tvOS)
+    import TVUIKit
+#endif
+
+internal class SignalManager {
+    
+    private let minimumWaitTimeBetweenRequests: Double = 10 // seconds
+    
+    private var signalCache: SignalCache<SignalPostBody>
+    let configuration: TelemetryManagerConfiguration
+    private var sendTimer: Timer?
+    
+    init(configuration: TelemetryManagerConfiguration) {
+        
+        self.configuration = configuration
+        
+        // We automatically load any old signals from disk on initialisation
+        signalCache = SignalCache(showDebugLogs: configuration.showDebugLogs)
+        
+        /// Before the app terminates, we want to save any pending signals to disk
+        /// We need to monitor different notifications for different devices.
+        /// iOS and macOS - We can simply wait for the app to terminate at which point we get enough time to save the cache
+        /// which is then restored when the app is cold started and all init's fire.
+        /// watchOS and tvOS - We can only really monitor moving to background and foreground to save/load the cache.
+        /// watchOS pre7.0 - Doesn't have any kind of notification to monitor.
+        #if os(iOS)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillTerminate), name: UIApplication.willTerminateNotification, object: nil)
+        #elseif os(macOS)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillTerminate), name: NSApplication.willTerminateNotification, object: nil)
+        #elseif os(watchOS)
+        if #available(watchOS 7.0, *) {
+            // We need to use a delay with these type of notifications because they fire on app load which causes a double load of the cache from disk
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                NotificationCenter.default.addObserver(self, selector: #selector(self.didEnterForeground), name: WKExtension.applicationWillEnterForegroundNotification, object: nil)
+                NotificationCenter.default.addObserver(self, selector: #selector(self.didEnterBackground), name: WKExtension.applicationDidEnterBackgroundNotification, object: nil)
+            }
+        } else {
+            // Pre watchOS 7.0, this library will not use disk caching at all as there are no notifications we can observe.
+        }
+        #elseif os(tvOS)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            // We need to use a delay with these type of notifications because they fire on app load which causes a double load of the cache from disk
+            NotificationCenter.default.addObserver(self, selector: #selector(self.didEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(self.didEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        }
+        #endif
+        
+        startTimer()
+    }
+    
+    /// Setup a timer to send the Signals
+    private func startTimer() {
+        
+        sendTimer?.invalidate()
+        
+        sendTimer = Timer.scheduledTimer(timeInterval: minimumWaitTimeBetweenRequests, target: self, selector: #selector(checkForSignalsAndSend), userInfo: nil, repeats: true)
+        
+        // Fire the timer to attempt to send any cached Signals from a previous session
+        checkForSignalsAndSend()
+    }
+    
+    /// Adds a signal to the process queue
+    func processSignal(_ signalType: TelemetrySignalType, for clientUser: String? = nil, with additionalPayload: [String: String] = [:], configuration: TelemetryManagerConfiguration) {
+        
+        DispatchQueue.global(qos: .utility).async { [self] in
+
+            let payLoad = SignalPayload(additionalPayload: additionalPayload)
+
+            let signalPostBody = SignalPostBody(
+                receivedAt: Date(),
+                type: "\(signalType)",
+                clientUser: sha256(str: clientUser ?? defaultUserIdentifier),
+                sessionID: configuration.sessionID.uuidString,
+                payload: payLoad.toDictionary()
+            )
+            
+            if (configuration.showDebugLogs) {
+                print("Process signal: \(signalPostBody)")
+            }
+            
+            signalCache.push(signalPostBody)
+        }
+    }
+    
+    /// Send signals once we have more than the minimum.
+    /// If any fail to send, we put them back into the cache to send later.
+    @objc
+    private func checkForSignalsAndSend() {
+        
+        if (configuration.showDebugLogs) {
+            print("Current signal cache count: \(signalCache.count())")
+        }
+        
+        let queuedSignals: [SignalPostBody] = signalCache.pop()
+        if !queuedSignals.isEmpty
+        {
+            if (configuration.showDebugLogs) {
+                print("Sending \(queuedSignals.count) signals leaving a cache of \(signalCache.count()) signals")
+            }
+            send(queuedSignals) { [unowned self] data, response, error in
+                
+                if let error = error {
+                    if (configuration.showDebugLogs) {
+                        print(error)
+                    }
+                    // The send failed, put the signal back into the queue
+                    self.signalCache.push(queuedSignals)
+                    return
+                }
+                
+                // Check for valid status code response
+                guard response?.statusCodeError() == nil else {
+                    let statusError = response!.statusCodeError()!
+                    if (configuration.showDebugLogs) {
+                        print(statusError)
+                    }
+                    // The send failed, put the signal back into the queue
+                    self.signalCache.push(queuedSignals)
+                    return
+                }
+                
+                if let data = data {
+                    if (configuration.showDebugLogs) {
+                        print(String(data: data, encoding: .utf8)!)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Notifications
+private extension SignalManager {
+    
+    @objc func appWillTerminate() {
+        if (configuration.showDebugLogs) {
+            print(#function)
+        }
+        
+        signalCache.backupCache()
+    }
+    
+    /// WatchOS doesn't have a notification before it's killed, so we have to use background/foreground
+    /// This means our `init()` above doesn't always run when coming back to foreground, so we have to manually
+    /// reload the cache. This also means we miss any signals sent during watchDidEnterForeground
+    /// so we merge them into the new cache.
+    #if os(watchOS) || os(tvOS)
+    @objc func didEnterForeground() {
+        if (configuration.showDebugLogs) {
+            print(#function)
+        }
+        
+        let currentCache = signalCache.pop()
+        if (configuration.showDebugLogs) {
+            print("current cache is \(currentCache.count) signals")
+        }
+        signalCache = SignalCache(showDebugLogs: configuration.showDebugLogs)
+        signalCache.push(currentCache)
+        
+        startTimer()
+    }
+    
+    @objc func didEnterBackground() {
+        if (configuration.showDebugLogs) {
+            print(#function)
+        }
+        
+        sendTimer?.invalidate()
+        sendTimer = nil
+        
+        signalCache.backupCache()
+    }
+    #endif
+}
+
+// MARK: - Comms
+private extension SignalManager {
+    
+    private func send(_ signalPostBodies: [SignalPostBody], completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
+        
+        DispatchQueue.global(qos: .utility).async { [self] in
+            let path = "/api/v1/apps/\(configuration.telemetryAppID)/signals/multiple/"
+            let url = configuration.telemetryServerBaseURL.appendingPathComponent(path)
+
+            var urlRequest = URLRequest(url: url)
+            urlRequest.httpMethod = "POST"
+            urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            urlRequest.httpBody = try! JSONEncoder.telemetryEncoder.encode(signalPostBodies)
+            if (configuration.showDebugLogs) {
+                print(String(data: urlRequest.httpBody!, encoding: .utf8)!)
+            }
+            
+            let task = URLSession.shared.dataTask(with: urlRequest, completionHandler: completionHandler)
+            task.resume()
+        }
+    }
+}
+
+// MARK: - Helpers
+private extension SignalManager {
+    
+    /// The default user identifier. If the platform supports it, the identifierForVendor. Otherwise, system version
+    /// and build number (in which case it's strongly recommended to supply an email or UUID or similar identifier for
+    /// your user yourself.
+    var defaultUserIdentifier: String {
+        #if os(iOS)
+        return UIDevice.current.identifierForVendor?.uuidString ?? "unknown user \(SignalPayload.systemVersion) \(SignalPayload.buildNumber)"
+        #elseif os(watchOS)
+            if #available(watchOS 6.2, *) {
+                return WKInterfaceDevice.current().identifierForVendor?.uuidString ?? "unknown user \(SignalPayload.systemVersion) \(SignalPayload.buildNumber)"
+            } else {
+                return "unknown user \(SignalPayload.platform) \(SignalPayload.systemVersion) \(SignalPayload.buildNumber)"
+            }
+        #else
+            #if DEBUG
+                print("[Telemetry] On this platform, Telemetry can't generate a unique user identifier. It is recommended you supply one yourself. More info: https://apptelemetry.io/pages/signal-reference.html")
+            #endif
+        return "unknown user \(SignalPayload.platform) \(SignalPayload.systemVersion) \(SignalPayload.buildNumber)"
+        #endif
+    }
+    
+    /**
+     * Example SHA 256 Hash using CommonCrypto
+     * CC_SHA256 API exposed from from CommonCrypto-60118.50.1:
+     * https://opensource.apple.com/source/CommonCrypto/CommonCrypto-60118.50.1/include/CommonDigest.h.auto.html
+     **/
+    func sha256(str: String) -> String {
+        if let strData = str.data(using: String.Encoding.utf8) {
+            /// #define CC_SHA256_DIGEST_LENGTH     32
+            /// Creates an array of unsigned 8 bit integers that contains 32 zeros
+            var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+
+            /// CC_SHA256 performs digest calculation and places the result in the caller-supplied buffer for digest (md)
+            /// Takes the strData referenced value (const unsigned char *d) and hashes it into a reference to the digest parameter.
+            _ = strData.withUnsafeBytes {
+                // CommonCrypto
+                // extern unsigned char *CC_SHA256(const void *data, CC_LONG len, unsigned char *md)  -|
+                // OpenSSL                                                                             |
+                // unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md)        <-|
+                CC_SHA256($0.baseAddress, UInt32(strData.count), &digest)
+            }
+
+            var sha256String = ""
+            /// Unpack each byte in the digest array and add them to the sha256String
+            for byte in digest {
+                sha256String += String(format: "%02x", UInt8(byte))
+            }
+
+            return sha256String
+        }
+        return ""
+    }
+}
+
+private extension URLResponse {
+    
+    /// Returns the HTTP status code
+    func statusCode() -> Int? {
+        if let httpResponse = self as? HTTPURLResponse {
+            return httpResponse.statusCode
+        }
+        return nil
+    }
+    
+    /// Returns an `Error` if not a valid statusCode
+    func statusCodeError() -> Error? {
+        
+        // Check for valid response in the 200-299 range
+        guard (200...299).contains(statusCode() ?? 0) else {
+            
+            if statusCode() == 401 {
+                return TelemetryError.Unauthorised
+            } else if statusCode() == 403 {
+                return TelemetryError.Forbidden
+            } else if statusCode() == 413 {
+                return TelemetryError.PayloadTooLarge
+            } else {
+                return TelemetryError.InvalidStatusCode(statusCode: statusCode() ?? 0)
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - Errors
+private enum TelemetryError: Error {
+    case Unauthorised
+    case Forbidden
+    case PayloadTooLarge
+    case InvalidStatusCode(statusCode:Int)
+}
+
+extension TelemetryError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .InvalidStatusCode(let statusCode):
+            return "Invaid status code \(statusCode)"
+        case .Unauthorised:
+            return "Unauthorized (401)"
+        case .Forbidden:
+            return "Forbidden (403)"
+        case .PayloadTooLarge:
+            return "Payload is too large (413)"
+        }
+    }
+}

--- a/Sources/TelemetryClient/TelemetryClient.h
+++ b/Sources/TelemetryClient/TelemetryClient.h
@@ -1,0 +1,18 @@
+//
+//  TelemetryClient.h
+//  TelemetryClient
+//
+//  Created by Darren Jones on 25/06/2021.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for TelemetryClient.
+FOUNDATION_EXPORT double TelemetryClientVersionNumber;
+
+//! Project version string for TelemetryClient.
+FOUNDATION_EXPORT const unsigned char TelemetryClientVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <TelemetryClient/PublicHeader.h>
+
+

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -5,18 +5,15 @@
 //  Copyright © 2019 breakthesystem. All rights reserved.
 //
 
-import CommonCrypto
 import Foundation
 
 #if os(iOS)
     import UIKit
-#endif
-
-#if os(watchOS)
+#elseif os(macOS)
+    import AppKit
+#elseif os(watchOS)
     import WatchKit
-#endif
-
-#if os(tvOS)
+#elseif os(tvOS)
     import TVUIKit
 #endif
 
@@ -26,6 +23,7 @@ public final class TelemetryManagerConfiguration {
     public let telemetryServerBaseURL: URL
     public var telemetryAllowDebugBuilds: Bool = false
     public var sessionID: UUID = UUID()
+    public var showDebugLogs: Bool = false
 
     public init(appID: String, baseURL: URL? = nil) {
         telemetryAppID = appID
@@ -75,253 +73,18 @@ public class TelemetryManager {
                 return
             }
         #endif
-
-        DispatchQueue.global().async { [self] in
-            let path = "/api/v1/apps/\(configuration.telemetryAppID)/signals/"
-            let url = configuration.telemetryServerBaseURL.appendingPathComponent(path)
-
-            var urlRequest = URLRequest(url: url)
-            urlRequest.httpMethod = "POST"
-            urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
-
-            let payLoad: [String: String] = [
-                "platform": platform,
-                "systemVersion": systemVersion,
-                "appVersion": appVersion,
-                "buildNumber": buildNumber,
-                "isSimulator": "\(isSimulator)",
-                "isTestFlight": "\(isTestFlight)",
-                "isAppStore": "\(isAppStore)",
-                "modelName": "\(modelName)",
-                "architecture": architecture,
-                "operatingSystem": operatingSystem,
-                "targetEnvironment": targetEnvironment,
-                "locale": locale,
-            ].merging(additionalPayload, uniquingKeysWith: { _, last in last })
-
-            let signalPostBody = SignalPostBody(
-                type: "\(signalType)",
-                clientUser: sha256(str: clientUser ?? defaultUserIdentifier),
-                sessionID: configuration.sessionID.uuidString,
-                payload: payLoad
-            )
-
-            urlRequest.httpBody = try! JSONEncoder().encode(signalPostBody)
-
-            let task = URLSession.shared.dataTask(with: urlRequest) { data, response, error in
-                if let error = error { print(error, data as Any, response as Any) }
-                if let data = data, let dataAsUTF8 = String(data: data, encoding: .utf8) {
-                    print(dataAsUTF8)
-                }
-            }
-            task.resume()
-        }
+        
+        signalManager.processSignal(signalType, for: clientUser, with: additionalPayload, configuration: configuration)
     }
 
     private init(configuration: TelemetryManagerConfiguration) {
         self.configuration = configuration
+        self.signalManager = SignalManager(configuration: configuration)
     }
 
     private static var initializedTelemetryManager: TelemetryManager?
 
     private let configuration: TelemetryManagerConfiguration
-
-    private struct SignalPostBody: Codable {
-        let type: String
-        let clientUser: String
-        let sessionID: String
-        let payload: [String: String]?
-    }
-}
-
-private extension TelemetryManager {
-    var isSimulatorOrTestFlight: Bool {
-        (isSimulator || isTestFlight)
-    }
-
-    var isSimulator: Bool {
-        #if targetEnvironment(simulator)
-            return true
-        #else
-            return false
-        #endif
-    }
-
-    var isTestFlight: Bool {
-        guard let path = Bundle.main.appStoreReceiptURL?.path else {
-            return false
-        }
-        return path.contains("sandboxReceipt")
-    }
-
-    var isAppStore: Bool {
-        !isSimulatorOrTestFlight
-    }
-
-    /// The operating system and its version
-    var systemVersion: String {
-        #if os(macOS)
-            return "\(platform) \(ProcessInfo.processInfo.operatingSystemVersion.majorVersion).\(ProcessInfo.processInfo.operatingSystemVersion.minorVersion).\(ProcessInfo.processInfo.operatingSystemVersion.patchVersion)"
-        #elseif os(iOS)
-            return "\(platform)  \(UIDevice.current.systemVersion)"
-        #elseif os(watchOS)
-            return "\(platform) \(WKInterfaceDevice.current().systemVersion)"
-        #elseif os(tvOS)
-            return "\(platform) \(UIDevice.current.systemVersion)"
-        #else
-            return "\(platform)"
-        #endif
-    }
-
-    /// The Bundle Short Version String, as described in Info.plist
-    var appVersion: String {
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-        return appVersion ?? "0"
-    }
-
-    /// The Bundle Version String, as described in Info.plist
-    var buildNumber: String {
-        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
-        return buildNumber ?? "0"
-    }
-
-    /// The default user identifier. If the platform supports it, the identifierForVendor. Otherwise, system version
-    /// and build number (in which case it's strongly recommended to supply an email or UUID or similar identifier for
-    /// your user yourself.
-    var defaultUserIdentifier: String {
-        #if os(iOS)
-            return UIDevice.current.identifierForVendor?.uuidString ?? "unknown user \(systemVersion) \(buildNumber)"
-        #elseif os(watchOS)
-            if #available(watchOS 6.2, *) {
-                return WKInterfaceDevice.current().identifierForVendor?.uuidString ?? "unknown user \(systemVersion) \(buildNumber)"
-            } else {
-                return "unknown user \(platform) \(systemVersion) \(buildNumber)"
-            }
-        #else
-            #if DEBUG
-                print("[Telemetry] On this platform, Telemetry can't generate a unique user identifier. It is recommended you supply one yourself. More info: https://apptelemetry.io/pages/signal-reference.html")
-            #endif
-            return "unknown user \(platform) \(systemVersion) \(buildNumber)"
-        #endif
-    }
-
-    /// The modelname as reported by systemInfo.machine
-    var modelName: String {
-        var systemInfo = utsname()
-        uname(&systemInfo)
-        let machineMirror = Mirror(reflecting: systemInfo.machine)
-        let identifier = machineMirror.children.reduce("") { identifier, element in
-            guard let value = element.value as? Int8, value != 0 else { return identifier }
-            return identifier + String(UnicodeScalar(UInt8(value)))
-        }
-        return identifier
-    }
-
-    /// The build architecture
-    var architecture: String {
-        #if arch(x86_64)
-            return "x86_64"
-        #elseif arch(arm)
-            return "arm"
-        #elseif arch(arm64)
-            return "arm64"
-        #elseif arch(i386)
-            return "i386"
-        #elseif arch(powerpc64)
-            return "powerpc64"
-        #elseif arch(powerpc64le)
-            return "powerpc64le"
-        #elseif arch(s390x)
-            return "s390x"
-        #else
-            return "unknown"
-        #endif
-    }
-
-    /// The operating system as reported by Swift. Note that this will report catalyst apps and iOS apps running on
-    /// macOS as "iOS". See `platform` for an alternative.
-    var operatingSystem: String {
-        #if os(macOS)
-            return "macOS"
-        #elseif os(iOS)
-            return "iOS"
-        #elseif os(watchOS)
-            return "watchOS"
-        #elseif os(tvOS)
-            return "tvOS"
-        #else
-            return "Unknown Operating System"
-        #endif
-    }
-
-    /// Based on the operating version reported by swift, but adding some smartness to better detect the actual
-    /// platform. Should correctly identify catalyst apps on macOS. Will probably not detect iOS apps running on
-    /// ARM based Macs.
-    var platform: String {
-        #if os(macOS)
-            return "macOS"
-        #elseif os(iOS)
-            #if targetEnvironment(macCatalyst)
-                return "macCatalyst"
-            #else
-                return "iOS"
-            #endif
-        #elseif os(watchOS)
-            return "watchOS"
-        #elseif os(tvOS)
-            return "tvOS"
-        #else
-            return "Unknown Platform"
-        #endif
-    }
-
-    /// The target environment as reported by swift. Either "simulator", "macCatalyst" or
-    var targetEnvironment: String {
-        #if targetEnvironment(simulator)
-            return "simulator"
-        #elseif targetEnvironment(macCatalyst)
-            return "macCatalyst"
-        #else
-            return "native"
-        #endif
-    }
     
-    /// The locale identifier
-    var locale: String {
-        return Locale.current.identifier
-    }
-}
-
-private extension TelemetryManager {
-    /**
-     * Example SHA 256 Hash using CommonCrypto
-     * CC_SHA256 API exposed from from CommonCrypto-60118.50.1:
-     * https://opensource.apple.com/source/CommonCrypto/CommonCrypto-60118.50.1/include/CommonDigest.h.auto.html
-     **/
-    func sha256(str: String) -> String {
-        if let strData = str.data(using: String.Encoding.utf8) {
-            /// #define CC_SHA256_DIGEST_LENGTH     32
-            /// Creates an array of unsigned 8 bit integers that contains 32 zeros
-            var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-
-            /// CC_SHA256 performs digest calculation and places the result in the caller-supplied buffer for digest (md)
-            /// Takes the strData referenced value (const unsigned char *d) and hashes it into a reference to the digest parameter.
-            _ = strData.withUnsafeBytes {
-                // CommonCrypto
-                // extern unsigned char *CC_SHA256(const void *data, CC_LONG len, unsigned char *md)  -|
-                // OpenSSL                                                                             |
-                // unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md)        <-|
-                CC_SHA256($0.baseAddress, UInt32(strData.count), &digest)
-            }
-
-            var sha256String = ""
-            /// Unpack each byte in the digest array and add them to the sha256String
-            for byte in digest {
-                sha256String += String(format: "%02x", UInt8(byte))
-            }
-
-            return sha256String
-        }
-        return ""
-    }
+    private let signalManager: SignalManager
 }

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -14,8 +14,45 @@ final class TelemetryClientTests: XCTestCase {
         TelemetryManager.send("userLoggedIn", for: "email")
         TelemetryManager.send("databaseUpdated", with: ["numberOfDatabaseEntries": "3831"])
     }
-
-    static var allTests = [
-        ("testExample", testExample),
-    ]
+    
+    func testPushAndPop() {
+        let signalCache = SignalCache<SignalPostBody>()
+        
+        let signals: [SignalPostBody] = [
+            .init(receivedAt: Date(), type: "01", clientUser: "01", sessionID: "01", payload: nil),
+            .init(receivedAt: Date(), type: "02", clientUser: "02", sessionID: "02", payload: nil),
+            .init(receivedAt: Date(), type: "03", clientUser: "03", sessionID: "03", payload: nil),
+            .init(receivedAt: Date(), type: "04", clientUser: "04", sessionID: "04", payload: nil),
+            .init(receivedAt: Date(), type: "05", clientUser: "05", sessionID: "05", payload: nil),
+            .init(receivedAt: Date(), type: "06", clientUser: "06", sessionID: "06", payload: nil),
+            .init(receivedAt: Date(), type: "07", clientUser: "07", sessionID: "07", payload: nil),
+            .init(receivedAt: Date(), type: "08", clientUser: "08", sessionID: "08", payload: nil),
+            .init(receivedAt: Date(), type: "09", clientUser: "09", sessionID: "09", payload: nil),
+            .init(receivedAt: Date(), type: "10", clientUser: "10", sessionID: "10", payload: nil),
+            .init(receivedAt: Date(), type: "11", clientUser: "11", sessionID: "11", payload: nil),
+            .init(receivedAt: Date(), type: "12", clientUser: "12", sessionID: "12", payload: nil),
+            .init(receivedAt: Date(), type: "13", clientUser: "13", sessionID: "13", payload: nil),
+            .init(receivedAt: Date(), type: "14", clientUser: "14", sessionID: "14", payload: nil),
+            .init(receivedAt: Date(), type: "15", clientUser: "15", sessionID: "15", payload: nil)
+        ]
+        
+        for signal in signals {
+            signalCache.push(signal)
+        }
+        
+        var allPoppedSignals: [SignalPostBody] = []
+        var poppedSignalsBatch: [SignalPostBody] = signalCache.pop()
+        while !poppedSignalsBatch.isEmpty {
+            allPoppedSignals.append(contentsOf: poppedSignalsBatch)
+            poppedSignalsBatch = signalCache.pop()
+        }
+        
+        XCTAssertEqual(signals.count, allPoppedSignals.count)
+        
+        allPoppedSignals.sort { lhs, rhs in
+            lhs.type < rhs.type
+        }
+        
+        XCTAssertEqual(signals, allPoppedSignals)
+    }
 }


### PR DESCRIPTION
Ok, so there's a lot going on here.

I've added your local caching but fixed a few bugs. I also made it generic and not specific to `SignalPostBody` as was suggested on Twitter.
The cache will load any previously unsent signals from disk on initialisation.
I've refactored the `SignalPayload` into it's own struct.
There's a new `SignalManager` that handles the cache, timer etc..
`SignalManager` will send a new batch of signals every 10 seconds and also once at startup (If any previous signals exist)
Signals are sent in batches of 25. Attempting with 50 sometimes resulted in a `Payload Too Large` error.
There's no mitigation if sending 25 gives this error, so maybe increase the payload size server side just to make sure.
If signals fail to send, they will be added back to the queue, so if a `Payload Too Large` error does occur, they will always be stuck in the cache.

The cache is saved to disk at different points depending on device/os:
- iOS will keep everything in memory until the app is completely killed by the system of killed from the App Switcher by the user.
- macOS will keep everything in memory until the app is quit.
- watchOS & tvOS will dump the cache to disk when the app is backgrounded and restore it when foregrounded.

There is a new `showDebugLogs` option on the `TelemetryManagerConfiguration` that will show very detailed logs of everything in action.

There are 4 new targets added to the project that I have thoroughly tested:
- iOS: To test the disk caching, you need to swipe the app up from the app switcher. On next run it will load the cache file. Stopping the app running via Xcode results in there being no disk cache file and a clean start next time.
- macOS: To test the disk caching, quit the app from either the menu bar, <kbd>Cmd</kbd> + <kbd>Q</kbd> or right clicking on the icon. Stopping the app running via Xcode results in there being no disk cache file and a clean start next time.
- watchOS: Disk caching can be tested by simply pressing the home button
- tvOS: Press <kbd>Esc</kbd> to background the app and save cache to disk. Use <kbd>&#8592;</kbd><kbd>&#8594;</kbd> + <kbd>Enter</kbd> to select the app and bring it back to foreground to load the disk cache.

You will notice that in the Xcode project there is a separate framework target for `watchOS`. This is necessary because building for `watchOS` builds both the `iOS` and `watchOS` targets and results in errors trying to add the `iOS` framework into a `watchOS` target. This is purely for the sample targets and shouldn't affect how the `SPM` package is delivered and built. (Someone else may be able to fix it to use the 1 framework 🤷‍♂️)

I have not updated the `README`