### PR TITLE
The wrong telemetryClientVersion is being sent

### DIFF
--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -11,7 +11,7 @@ import Foundation
 #endif
 
 
-let TelemetryClientVersion = "SwiftClient 1.0.14"
+let TelemetryClientVersion = "SwiftClient 1.1.1"
 
 public typealias TelemetrySignalType = String
 


### PR DESCRIPTION
Client v1.1.0 is sending "SwiftClient 1.0.14"
Guessing the next release is 1.1.1!