### PR TITLE
Write and load signal cache on background/foreground for iOS as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ struct TelemetryTestApp: App {
     
     init() {
         // Note: Do not add this code to `WindowGroup.onAppear`, which will be called 
-        //       *after* your window has been initialized, and might lead to out initialization
+        //       *after* your window has been initialized, and might lead to our initialization
         //       occurring too late.
         let configuration = TelemetryManagerConfiguration(appID: "<YOUR-APP-ID>")
         TelemetryManager.initialize(with: configuration)


### PR DESCRIPTION
App termination is an unreliable way to do background work on iOS. It is more reliable to use background/foreground events (as is already being done in watchOS and tvOS), so moving iOS code to use those paths as well.

Also one quick drive-by typo correction in README